### PR TITLE
Added 3 new dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ Note: Original source was not properly licensed, only mention of license was to 
 
 Here is the list of extensions the pack includes:
 
-[Angular Language Service](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template), [tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint), [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense), [Sort lines](https://marketplace.visualstudio.com/items?itemName=Tyriar.sort-lines), [Angular v5 Snippets](https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2)
+* [Angular Language Service](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template)
+* [tslint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
+* [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense)
+* [Sort lines](https://marketplace.visualstudio.com/items?itemName=Tyriar.sort-lines)
+* [Angular v5 Snippets](https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2)
+* [EditConfig](https://marketplace.visualstudio.com/items?itemName=editorconfig.editorconfig)
+* [Angular2-Inline](https://marketplace.visualstudio.com/items?itemName=natewallace.angular2-inline)
+* [Debugger For Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) 
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
         "eg2.tslint",
         "christian-kohler.path-intellisense",
         "johnpapa.Angular2",
-        "Tyriar.sort-lines"
+        "Tyriar.sort-lines",
+        "editorconfig.editorconfig",
+        "natewallace.angular2-inline",
+        "msjsdiag.debugger-for-chrome"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
         "Angular 2",
         "Angular 4",
         "TypeScript",
+        "Essentials",
         "HTML"
     ],
-    "version": "1.0.4",
+    "version": "1.1.0",
     "publisher": "brain",
     "engines": {
         "vscode": "^1.12.0"


### PR DESCRIPTION
Added editorconfig, angular2-inline and debugger for chrome.
The difference between bare-essentials and angular-essentials is now only that bare-essentials does not include theme extentions, prettier and the npm extention